### PR TITLE
Landmarks to HTML naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The plugin was developed by members of the accessibility and design teams at eBa
 - [ ] Add delete in multiple steps
 - [X] Updates for keyboard navigation (v10)
 - [X] Generate Responsive Designs from a single design (v10)
+- [X] Rename landmarks to use the HTML names (e.g. footer) and not aria roles (e.g. contentinfo).
 
 **Future explorations**
 

--- a/src/data/landmark-types.js
+++ b/src/data/landmark-types.js
@@ -5,36 +5,36 @@ import SvgLandmarks from '../icons/landmarks';
 
 // setup landmark options
 export default {
-  banner: {
+  header: {
     icon: <SvgLandmarks.SvgBanner />,
-    label: 'banner'
+    label: '<header>'
   },
   search: {
     icon: <SvgLandmarks.SvgSearch />,
     label: 'search'
   },
-  navigation: {
+  nav: {
     icon: <SvgLandmarks.SvgNavigation />,
-    label: 'navigation'
+    label: '<nav>'
   },
   main: {
     icon: <SvgLandmarks.SvgMain />,
-    label: 'main'
+    label: '<main>'
   },
-  'content-info': {
+  footer: {
     icon: <SvgLandmarks.SvgContentInfo />,
-    label: 'content info'
+    label: '<footer>'
   },
-  complimentary: {
+  aside: {
     icon: <SvgLandmarks.SvgComplimentary />,
-    label: 'complimentary'
+    label: '<aside>'
   },
   form: {
     icon: <SvgLandmarks.SvgForm />,
-    label: 'form'
+    label: '<form>'
   },
-  region: {
+  section: {
     icon: <SvgLandmarks.SvgRegion />,
-    label: 'region'
+    label: '<section>'
   }
 };

--- a/src/figma-code/onload-plugin.js
+++ b/src/figma-code/onload-plugin.js
@@ -35,6 +35,18 @@ const isA11yLayer = (children, childNode, name) => {
       utils.nameBeforePipe(child.name) === 'Accessibility annotations Layer'
   );
 
+  // old landmarks mapper (legacy)
+  const marksLegacy = {
+    banner: 'header',
+    search: 'search',
+    navigation: 'nav',
+    main: 'main',
+    'content-info': 'footer',
+    complimentary: 'aside',
+    form: 'form',
+    region: 'section'
+  };
+
   // loop through a11y layer steps
   for (let j = 0; j < frameChildren.length; j += 1) {
     const frameChild = frameChildren[j];
@@ -79,12 +91,15 @@ const isA11yLayer = (children, childNode, name) => {
 
           // if we have a label, grab it
           const [type, label = null] = typeName.split(':');
+          const typeTrim = type.trim();
+          const newType =
+            typeTrim in marksLegacy ? marksLegacy[typeTrim] : typeTrim;
 
           landmarks[landmarkObj.id] = {
             id: landmarkObj.id,
             label: label !== null ? label.trim() : label,
             name: landmarkObj.name,
-            type: type.trim()
+            type: newType
           };
         }
       }

--- a/src/figma-code/steps/landmarks.js
+++ b/src/figma-code/steps/landmarks.js
@@ -3,6 +3,9 @@ import { createTransparentFrame } from '../../constants/figma-layer';
 import config from '../config';
 import { getOrCreateMainA11yFrame } from '../frame-helpers';
 
+// data
+import landmarksTypesObj from '../../data/landmark-types';
+
 const landmarkLayerName = 'Landmarks Layer';
 
 export const noLandmarks = (msg) => {
@@ -75,6 +78,7 @@ export const noLandmarks = (msg) => {
 
 export const add = (msg) => {
   const { bounds, landmark, page, pageId, pageType } = msg;
+  const { label } = landmarksTypesObj[landmark];
 
   const mainPageNode = figma.getNodeById(pageId);
 
@@ -119,7 +123,7 @@ export const add = (msg) => {
   const landmarkBlockName = `Landmark: ${landmark} | ${landmarkBlock.id}`;
   landmarkBlock.name = landmarkBlockName;
 
-  // Create rectangle / background
+  // create rectangle / background
   const rectNode = figmaLayer.createRectangle({
     name: `Landmark Area: ${landmark}`,
     height: 100,
@@ -136,9 +140,6 @@ export const add = (msg) => {
   // add rectangle within Landmark layer
   landmarkBlock.appendChild(rectNode);
 
-  // create annotation label
-  const landmarkDisplay = utils.capitalize(landmark).replace(/-/g, ' ');
-
   // Create label background with auto-layout
   const labelFrame = figmaLayer.createFrame({
     name: 'Label Background',
@@ -153,7 +154,8 @@ export const add = (msg) => {
   labelFrame.verticalPadding = 8;
   labelFrame.counterAxisSizingMode = 'AUTO';
   labelFrame.cornerRadius = 8;
-  // Do NOT have it scale with the surrounding frame
+
+  // do NOT have it scale with the surrounding frame
   labelFrame.constraints = {
     horizontal: 'MIN',
     vertical: 'MIN'
@@ -161,9 +163,9 @@ export const add = (msg) => {
 
   // create annotation name for label
   const labelNode = figma.createText();
-  labelNode.name = `Landmark Name: ${landmarkDisplay}`;
+  labelNode.name = `Landmark Name: ${label}`;
   labelNode.fontSize = 15;
-  labelNode.characters = landmarkDisplay;
+  labelNode.characters = label;
   labelNode.fills = [{ type: 'SOLID', color: colors.white }];
   labelNode.fontName = { family: 'Roboto', style: 'Bold' };
 
@@ -199,6 +201,11 @@ export const add = (msg) => {
       name: landmarkBlockName
     }
   });
+
+  // collapse all frames
+  landmarksFrame.expanded = false;
+  labelFrame.expanded = false;
+  landmarkBlock.expanded = false;
 };
 
 export const completed = (msg) => {
@@ -280,6 +287,7 @@ export const completed = (msg) => {
 
 export const updateWithLabel = (msg) => {
   const { id, value, landmarkType } = msg;
+  const { label } = landmarksTypesObj[landmarkType];
 
   // get landmark
   const landmarkNode = figma.getNodeById(id);
@@ -295,12 +303,9 @@ export const updateWithLabel = (msg) => {
     return;
   }
 
-  // format some values
-  const landmarkTypeCap = utils.capitalize(landmarkType);
-
   // set width of label background to account for new length
   const newValue = utils.capitalize(value.toLowerCase());
-  const newLabel = `${landmarkTypeCap}: ${newValue}`;
+  const newLabel = `${label} ${newValue}`;
   const widthMin = 52;
   const labelWidth = Math.floor(newLabel.length * 9.5);
   const newLabelWidth = labelWidth < widthMin ? widthMin : labelWidth;

--- a/src/pages/Landmarks.js
+++ b/src/pages/Landmarks.js
@@ -19,7 +19,7 @@ import Context from '../context';
 import landmarksTypesObj from '../data/landmark-types';
 
 const landmarksTypesArray = Object.keys(landmarksTypesObj);
-const landmarksOnlyOnce = ['main', 'banner', 'content-info'];
+const landmarksOnlyOnce = ['main', 'header', 'footer'];
 
 function Landmarks() {
   // main app state
@@ -218,6 +218,7 @@ function Landmarks() {
           <React.Fragment>
             {landmarksArray.map((key) => {
               const { id, label, type } = landmarks[key];
+              const { label: labelType } = landmarksTypesObj[type];
 
               const showLabel = label !== null || needsLabel.includes(id);
               const hasTempLabel = labelsTemp[id]?.value || label;
@@ -231,7 +232,7 @@ function Landmarks() {
               return (
                 <div key={key} className="row-landmark flex-row-space-between">
                   <div className="flex-row-center">
-                    <div className="landmark-type">{`${type} Landmark`}</div>
+                    <div className="landmark-type">{`${labelType} Landmark`}</div>
 
                     {showLabel && (
                       <React.Fragment>


### PR DESCRIPTION
## Description

Rename landmarks to use the HTML names (e.g. footer) and not aria roles (e.g. contentinfo).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document and agree to the project's Code of Conduct
- [X] I have updated/added documentation affected by my changes (in DOCS.md).
