### PR TITLE
Handle Long Preloading Times

### DIFF
--- a/src/pages/ProgressLoading.js
+++ b/src/pages/ProgressLoading.js
@@ -4,23 +4,29 @@ import PropTypes from 'prop-types';
 // components
 import { LoadingSpinner } from '../components';
 
-function ProgressLoading({ message }) {
+// icons
+import { SvgWarning } from '../icons';
+
+function ProgressLoading({ message, showWarning }) {
   return (
     <div className="h-100 w-100 flex-center">
-      <LoadingSpinner size={24} />
+      {showWarning === false && <LoadingSpinner size={24} />}
+      {showWarning === true && <SvgWarning size={24} />}
 
-      <div className="muted pt2">{message}</div>
+      <div className="loading-message">{message}</div>
     </div>
   );
 }
 
 ProgressLoading.defaultProps = {
-  message: 'Scanning for Accessibility layers in Figma document'
+  message: 'Scanning for Accessibility layers in Figma document',
+  showWarning: false
 };
 
 ProgressLoading.propTypes = {
   // optional
-  message: PropTypes.string
+  message: PropTypes.string,
+  showWarning: PropTypes.bool
 };
 
 export default React.memo(ProgressLoading);

--- a/src/styles/shared.scss
+++ b/src/styles/shared.scss
@@ -359,3 +359,10 @@ input {
   border-radius: 16px;
   color: var(--figma-color-text-success);
 }
+
+.loading-message {
+  color: var(--figma-color-text-disabled);
+  max-width: 380px;
+  padding-top: var(--spacing-sm);
+  text-align: center;
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -47,9 +47,40 @@ function App() {
 
   // local state
   const [progressPercent, setPercentage] = React.useState(null);
+  const [loadingMsg, setLoadingMsg] = React.useState(
+    'Scanning for Accessibility layers in Figma document'
+  );
+  const [showLoadingWarning, setLoadingWarning] = React.useState(false);
 
   // hook for route changes
   const location = useLocation();
+
+  // on load, start timers for 15 seconds and 60 seconds using a useEffect
+  // if isLoading state changes, cancel timers
+  React.useEffect(() => {
+    let timer15;
+    let timer60;
+
+    if (isLoading === true) {
+      timer15 = setTimeout(() => {
+        setLoadingMsg(
+          'If you have a lot of pages with annotations, and high-res images, try moving them to their own Figma page to get it to load faster.'
+        );
+      }, 15000);
+
+      timer60 = setTimeout(() => {
+        setLoadingMsg(
+          "We couldn't load the annotations. If you have a lot of pages with annotations, and high-res images, try moving them to their own Figma page to get it to load faster."
+        );
+        setLoadingWarning(true);
+      }, 60000);
+    }
+
+    return () => {
+      clearTimeout(timer15);
+      clearTimeout(timer60);
+    };
+  }, [isLoading]);
 
   // listen for route change, adjust show/hide layers in Figma document
   React.useEffect(() => {
@@ -115,7 +146,9 @@ function App() {
 
   // loading/scanning for a11y progress on current Figma document
   if (isLoading) {
-    return <ProgressLoading />;
+    return (
+      <ProgressLoading message={loadingMsg} showWarning={showLoadingWarning} />
+    );
   }
 
   // show page change alert


### PR DESCRIPTION
## Description

added timers for slow preloading times:
- if app takes 15 seconds, shows another message
- if app takes 60 seconds, shows a warning state and another message

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document and agree to the project's Code of Conduct
- [X] I have updated/added documentation affected by my changes (in DOCS.md).
