### PR TITLE
[Fix] Prevent image alternative text from resetting when adding a new image manually

### DIFF
--- a/src/pages/AltText.js
+++ b/src/pages/AltText.js
@@ -114,12 +114,13 @@ function AltText() {
       // map new images scanned to array of objects for alt text, etc.
       const newImagesData = imagesScanned.map((image) => {
         const { altText, id, name, bounds, type } = image;
+        const existingData = imagesData.find((img) => img.id === id);
 
         return {
           id,
           name,
-          altText,
-          type,
+          altText: existingData ? existingData.altText : altText,
+          type: existingData ? existingData.type : type,
           bounds
         };
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When adding a new image to the alternative text step, the type and alternative text will reset back to their original loaded state. 

There is still an issue when exiting clicking 'go to dashboard' and opening the previous page, where the image list is not correctly loaded. 

A full plugin reload resolves the scanned and manually added images list and shows all correct data. 

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and agree to the project's Code of Conduct
- [ ] I have updated/added documentation affected by my changes (in DOCS.md).
